### PR TITLE
chore: standardize CODEOWNERS file

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,4 +1,4 @@
 # Default code owners
-* @platform-mesh/frame @platform-mesh/go-approvers
+* @platform-mesh/frame @platform-mesh/tsc @platform-mesh/go-approvers
 go.mod
 go.sum


### PR DESCRIPTION
Standardize the CODEOWNERS file to use the common pattern across all Go repositories.

## Changes
- Set code owners to `@platform-mesh/frame @platform-mesh/tsc @platform-mesh/go-approvers`
- Exclude `go.mod` and `go.sum` from ownership requirements