### PR TITLE
feat: add marketplace scope filtering for org-level providers

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -8,7 +8,8 @@ type ServiceConfig struct {
 	EntityLabel       string
 	ContentForLabel   string
 	MainEntityName    string
-	AccountEntityName string
+	AccountEntityName     string
+	MarketplaceScopeLabel string
 
 	ResourceSchemaName      string
 	ResourceSchemaWorkspace string
@@ -22,6 +23,7 @@ func NewServiceConfig() ServiceConfig {
 		ContentForLabel:         "ui.platform-mesh.io/content-for",
 		MainEntityName:          "main",
 		AccountEntityName:       "core_platform-mesh_io_account",
+		MarketplaceScopeLabel:   "ui.platform-mesh.io/scope",
 		ResourceSchemaName:      "v250704-6d57f16.contentconfigurations.ui.platform-mesh.io",
 		ResourceSchemaWorkspace: "root:openmfp-system",
 	}
@@ -34,6 +36,7 @@ func (c *ServiceConfig) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&c.ContentForLabel, "content-for-label", c.ContentForLabel, "Set the content-for label")
 	fs.StringVar(&c.MainEntityName, "main-entity-name", c.MainEntityName, "Set the main entity name")
 	fs.StringVar(&c.AccountEntityName, "account-entity-name", c.AccountEntityName, "Set the account entity name")
+	fs.StringVar(&c.MarketplaceScopeLabel, "marketplace-scope-label", c.MarketplaceScopeLabel, "Label used to scope providers to org or account level")
 	fs.StringVar(&c.ResourceSchemaName, "resource-schema-name", c.ResourceSchemaName, "Set the resource schema name")
 	fs.StringVar(&c.ResourceSchemaWorkspace, "resource-schema-workspace", c.ResourceSchemaWorkspace, "Set the resource schema workspace")
 	fs.StringVar(

--- a/pkg/storage/filter.go
+++ b/pkg/storage/filter.go
@@ -267,12 +267,32 @@ func Marketplace(ctx context.Context, cfg config.ServiceConfig, dynamicClient dy
 			var results unstructured.UnstructuredList
 			results.SetGroupVersionKind(v1alpha1.GroupVersion.WithKind("MarketplaceEntryList"))
 
+			// Determine workspace scope for provider filtering
+			var requestedScope string
+			if path, ok := ClusterPathFrom(ctx); ok {
+				if parentPath, hasParent := path.Parent(); hasParent {
+					if strings.HasSuffix(parentPath.String(), "orgs") {
+						requestedScope = "org"
+					} else {
+						requestedScope = "account"
+					}
+				}
+			}
+
 			err = providers.EachListItem(func(o runtime.Object) error {
 
 				var provider extensionapiv1alpha1.ProviderMetadata
 				err := runtime.DefaultUnstructuredConverter.FromUnstructured(o.(*unstructured.Unstructured).Object, &provider)
 				if err != nil {
 					return err
+				}
+
+				// Scope filtering: skip providers that don't match the current workspace level.
+				// No label means show everywhere (backward compatible).
+				if providerScope := provider.GetLabels()[cfg.MarketplaceScopeLabel]; providerScope != "" && requestedScope != "" {
+					if providerScope != requestedScope {
+						return nil
+					}
 				}
 
 				rawExports, err := resourceClient.Cluster(logicalcluster.Wildcard).Resource(


### PR DESCRIPTION
## Summary

Add optional scope filtering to the marketplace virtual workspace. Providers can be scoped to org or account level using the `ui.platform-mesh.io/scope` label on ProviderMetadata.

## Changes

- `pkg/config/config.go`: Add `MarketplaceScopeLabel` config field
- `pkg/storage/filter.go`: Add scope check in `Marketplace()` lister, after ProviderMetadata decode, before APIExport lookup

## Behavior

| Label | Effect |
|-------|--------|
| No label | Show everywhere (backward compatible) |
| `ui.platform-mesh.io/scope: org` | Show only at org level |
| `ui.platform-mesh.io/scope: account` | Show only at account level |

## Context

Needed for org-level provider installation (e.g., OpenKCM governance). Without this, all providers appear at all workspace levels regardless of their intended scope.

Uses the same workspace level detection as `ContentConfigurationLookup()` — `ClusterPathFrom(ctx)` + parent path suffix check.

## Test plan

- [ ] Existing providers (no scope label) continue to appear at all levels
- [ ] Provider with `scope: org` only appears at org level
- [ ] Provider with `scope: account` only appears at account level
- [ ] Missing cluster path in context → no filtering (fail open)