### PR TITLE
test: add CRD roundtrip fuzz tests

### DIFF
--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -32,6 +32,12 @@ tasks:
       - task: manifests
       - "{{.LOCAL_BIN}}/controller-gen object paths=./..."
       - "{{.LOCAL_BIN}}/apigen --input-dir {{.CRD_DIRECTORY}} --output-dir ./config/resources"
+  fuzz:
+    desc: "Run fuzz tests with a configurable duration (default 30s per target)"
+    vars:
+      FUZZTIME: '{{.FUZZTIME | default "30s"}}'
+    cmds:
+      - go test ./api/v1alpha1/ -run=^$ -fuzz=FuzzMarketplaceEntryRoundTrip -fuzztime={{.FUZZTIME}} -count=1
   docker-build:
     cmds:
       - docker build .

--- a/api/v1alpha1/roundtrip_fuzz_test.go
+++ b/api/v1alpha1/roundtrip_fuzz_test.go
@@ -1,0 +1,57 @@
+package v1alpha1
+
+import (
+	"encoding/json"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/api/equality"
+)
+
+func FuzzMarketplaceEntryRoundTrip(f *testing.F) {
+	f.Add([]byte(`{
+		"apiVersion": "virtual-workspaces.platform-mesh.io/v1alpha1",
+		"kind": "MarketplaceEntry",
+		"metadata": {"name": "my-extension", "labels": {"app": "test"}},
+		"spec": {
+			"installed": true,
+			"providerMetadata": {
+				"displayName": "My Extension",
+				"description": "An example marketplace extension",
+				"tags": ["networking", "security"],
+				"contacts": [{"displayName": "Support", "email": "support@example.com", "role": ["maintainer"]}],
+				"documentation": [{"displayName": "Docs", "url": "https://example.com/docs"}],
+				"links": [{"displayName": "Homepage", "url": "https://example.com"}]
+			},
+			"apiExport": {
+				"metadata": {"name": "test-api-export"},
+				"spec": {}
+			}
+		}
+	}`))
+	f.Add([]byte(`{}`))
+	f.Add([]byte(`{"spec": {"installed": false, "providerMetadata": {"displayName": ""}}}`))
+	f.Fuzz(func(t *testing.T, data []byte) {
+		fuzzRoundTrip(t, data, &MarketplaceEntry{}, &MarketplaceEntry{})
+	})
+}
+
+func fuzzRoundTrip[T any](t *testing.T, data []byte, obj *T, obj2 *T) {
+	t.Helper()
+
+	if err := json.Unmarshal(data, obj); err != nil {
+		return
+	}
+
+	roundtripped, err := json.Marshal(obj)
+	if err != nil {
+		t.Fatalf("failed to marshal: %v", err)
+	}
+
+	if err := json.Unmarshal(roundtripped, obj2); err != nil {
+		t.Fatalf("failed to unmarshal roundtripped data: %v", err)
+	}
+
+	if !equality.Semantic.DeepEqual(obj, obj2) {
+		t.Errorf("roundtrip mismatch for %T", obj)
+	}
+}


### PR DESCRIPTION
## Summary
- Add CRD roundtrip fuzz test for MarketplaceEntry using equality.Semantic.DeepEqual
- Add `task fuzz` entry to Taskfile for on-demand mutation fuzzing

Closes #100
Part of platform-mesh/backlog#231